### PR TITLE
[Migration] RaisedButton to ElevatedButton and FlatButton to TextButton

### DIFF
--- a/lib/screens/elements.dart
+++ b/lib/screens/elements.dart
@@ -55,16 +55,18 @@ class _ElementsState extends State<Elements> {
                 child: Padding(
                   padding:
                       const EdgeInsets.only(left: 34.0, right: 34.0, top: 16),
-                  child: RaisedButton(
-                    textColor: ArgonColors.white,
-                    color: ArgonColors.initial,
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      foregroundColor: ArgonColors.white,
+                      backgroundColor: ArgonColors.initial,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(4.0),
+                      ),
+                    ),
                     onPressed: () {
                       // Respond to button press
                       Navigator.pushReplacementNamed(context, '/home');
                     },
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(4.0),
-                    ),
                     child: Padding(
                         padding: EdgeInsets.only(
                             left: 16.0, right: 16.0, top: 12, bottom: 12),
@@ -79,16 +81,18 @@ class _ElementsState extends State<Elements> {
                 child: Padding(
                   padding:
                       const EdgeInsets.only(left: 34.0, right: 34.0, top: 8),
-                  child: RaisedButton(
-                    textColor: ArgonColors.text,
-                    color: ArgonColors.secondary,
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      foregroundColor: ArgonColors.text,
+                      backgroundColor: ArgonColors.secondary,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(4.0),
+                      ),
+                    ),
                     onPressed: () {
                       // Respond to button press
                       Navigator.pushReplacementNamed(context, '/home');
                     },
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(4.0),
-                    ),
                     child: Padding(
                         padding: EdgeInsets.only(
                             left: 16.0, right: 16.0, top: 12, bottom: 12),
@@ -103,16 +107,18 @@ class _ElementsState extends State<Elements> {
                 child: Padding(
                   padding:
                       const EdgeInsets.only(left: 34.0, right: 34.0, top: 8),
-                  child: RaisedButton(
-                    textColor: ArgonColors.white,
-                    color: ArgonColors.primary,
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      foregroundColor: ArgonColors.white,
+                      backgroundColor: ArgonColors.primary,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(4.0),
+                      ),
+                    ),
                     onPressed: () {
                       // Respond to button press
                       Navigator.pushReplacementNamed(context, '/home');
                     },
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(4.0),
-                    ),
                     child: Padding(
                         padding: EdgeInsets.only(
                             left: 16.0, right: 16.0, top: 12, bottom: 12),
@@ -127,16 +133,18 @@ class _ElementsState extends State<Elements> {
                 child: Padding(
                   padding:
                       const EdgeInsets.only(left: 34.0, right: 34.0, top: 8),
-                  child: RaisedButton(
-                    textColor: ArgonColors.white,
-                    color: ArgonColors.info,
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      foregroundColor: ArgonColors.white,
+                      backgroundColor: ArgonColors.info,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(4.0),
+                      ),
+                    ),
                     onPressed: () {
                       // Respond to button press
                       Navigator.pushReplacementNamed(context, '/home');
                     },
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(4.0),
-                    ),
                     child: Padding(
                         padding: EdgeInsets.only(
                             left: 16.0, right: 16.0, top: 12, bottom: 12),
@@ -151,16 +159,18 @@ class _ElementsState extends State<Elements> {
                 child: Padding(
                   padding:
                       const EdgeInsets.only(left: 34.0, right: 34.0, top: 8),
-                  child: RaisedButton(
-                    textColor: ArgonColors.white,
-                    color: ArgonColors.success,
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      foregroundColor: ArgonColors.white,
+                      backgroundColor: ArgonColors.success,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(4.0),
+                      ),
+                    ),
                     onPressed: () {
                       // Respond to button press
                       Navigator.pushReplacementNamed(context, '/home');
                     },
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(4.0),
-                    ),
                     child: Padding(
                         padding: EdgeInsets.only(
                             left: 16.0, right: 16.0, top: 12, bottom: 12),
@@ -175,16 +185,18 @@ class _ElementsState extends State<Elements> {
                 child: Padding(
                   padding:
                       const EdgeInsets.only(left: 34.0, right: 34.0, top: 8),
-                  child: RaisedButton(
-                    textColor: ArgonColors.white,
-                    color: ArgonColors.warning,
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      foregroundColor: ArgonColors.white,
+                      backgroundColor: ArgonColors.warning,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(4.0),
+                      ),
+                    ),
                     onPressed: () {
                       // Respond to button press
                       Navigator.pushReplacementNamed(context, '/home');
                     },
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(4.0),
-                    ),
                     child: Padding(
                         padding: EdgeInsets.only(
                             left: 16.0, right: 16.0, top: 12, bottom: 12),
@@ -199,16 +211,18 @@ class _ElementsState extends State<Elements> {
                 child: Padding(
                   padding:
                       const EdgeInsets.only(left: 34.0, right: 34.0, top: 8),
-                  child: RaisedButton(
-                    textColor: ArgonColors.white,
-                    color: ArgonColors.error,
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      foregroundColor: ArgonColors.white,
+                      backgroundColor: ArgonColors.error,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(4.0),
+                      ),
+                    ),
                     onPressed: () {
                       // Respond to button press
                       Navigator.pushReplacementNamed(context, '/home');
                     },
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(4.0),
-                    ),
                     child: Padding(
                         padding: EdgeInsets.only(
                             left: 16.0, right: 16.0, top: 12, bottom: 12),

--- a/lib/screens/onboarding.dart
+++ b/lib/screens/onboarding.dart
@@ -51,15 +51,17 @@ class Onboarding extends StatelessWidget {
                   padding: const EdgeInsets.only(top: 16.0),
                   child: SizedBox(
                     width: double.infinity,
-                    child: FlatButton(
-                      textColor: ArgonColors.text,
-                      color: ArgonColors.secondary,
+                    child: TextButton(
+                      style: TextButton.styleFrom(
+                        foregroundColor: ArgonColors.text,
+                        backgroundColor: ArgonColors.secondary,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(4.0),
+                        ),
+                      ),
                       onPressed: () {
                         Navigator.pushReplacementNamed(context, '/home');
                       },
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(4.0),
-                      ),
                       child: Padding(
                           padding: EdgeInsets.only(
                               left: 16.0, right: 16.0, top: 12, bottom: 12),

--- a/lib/screens/pro.dart
+++ b/lib/screens/pro.dart
@@ -83,13 +83,15 @@ class Pro extends StatelessWidget {
                   padding: const EdgeInsets.only(top: 16.0),
                   child: SizedBox(
                     width: double.infinity,
-                    child: FlatButton(
-                      textColor: ArgonColors.white,
-                      color: ArgonColors.info,
-                      onPressed: _launchURL,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(4.0),
+                    child: TextButton(
+                      style: TextButton.styleFrom(
+                        foregroundColor: ArgonColors.white,
+                        backgroundColor: ArgonColors.info,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(4.0),
+                        ),
                       ),
+                      onPressed: _launchURL,
                       child: Padding(
                           padding: EdgeInsets.only(
                               left: 16.0, right: 16.0, top: 12, bottom: 12),

--- a/lib/screens/register.dart
+++ b/lib/screens/register.dart
@@ -76,13 +76,15 @@ class _RegisterState extends State<Register> {
                                         Container(
                                           // width: 0,
                                           height: 36,
-                                          child: RaisedButton(
-                                              textColor: ArgonColors.primary,
-                                              color: ArgonColors.secondary,
-                                              onPressed: () {},
-                                              shape: RoundedRectangleBorder(
+                                          child: ElevatedButton(
+                                              style: ElevatedButton.styleFrom(
+                                                foregroundColor: ArgonColors.primary,
+                                                backgroundColor: ArgonColors.secondary,
+                                                shape: RoundedRectangleBorder(
                                                   borderRadius:
                                                       BorderRadius.circular(4)),
+                                              ),
+                                              onPressed: () {},
                                               child: Padding(
                                                   padding: EdgeInsets.only(
                                                       bottom: 10,
@@ -113,13 +115,15 @@ class _RegisterState extends State<Register> {
                                         Container(
                                           // width: 0,
                                           height: 36,
-                                          child: RaisedButton(
-                                              textColor: ArgonColors.primary,
-                                              color: ArgonColors.secondary,
-                                              onPressed: () {},
-                                              shape: RoundedRectangleBorder(
+                                          child: ElevatedButton(
+                                              style: ElevatedButton.styleFrom(
+                                                foregroundColor: ArgonColors.primary,
+                                                backgroundColor: ArgonColors.secondary,
+                                                shape: RoundedRectangleBorder(
                                                   borderRadius:
                                                       BorderRadius.circular(4)),
+                                              ),
+                                              onPressed: () {},
                                               child: Padding(
                                                   padding: EdgeInsets.only(
                                                       bottom: 10,
@@ -260,18 +264,20 @@ class _RegisterState extends State<Register> {
                                       Padding(
                                         padding: const EdgeInsets.only(top: 16),
                                         child: Center(
-                                          child: FlatButton(
-                                            textColor: ArgonColors.white,
-                                            color: ArgonColors.primary,
+                                          child: TextButton(
+                                            style: TextButton.styleFrom(
+                                              foregroundColor: ArgonColors.white,
+                                              backgroundColor: ArgonColors.primary,
+                                              shape: RoundedRectangleBorder(
+                                                borderRadius:
+                                                    BorderRadius.circular(4.0),
+                                              ),
+                                            ),
                                             onPressed: () {
                                               // Respond to button press
                                               Navigator.pushNamed(
                                                   context, '/home');
                                             },
-                                            shape: RoundedRectangleBorder(
-                                              borderRadius:
-                                                  BorderRadius.circular(4.0),
-                                            ),
                                             child: Padding(
                                                 padding: EdgeInsets.only(
                                                     left: 16.0,

--- a/lib/widgets/button.dart
+++ b/lib/widgets/button.dart
@@ -48,10 +48,19 @@ class StretchableButton extends StatelessWidget {
             borderRadius: BorderRadius.circular(borderRadius),
             side: bs,
           ),
-          child: RaisedButton(
+          child: ElevatedButton(
             onPressed: onPressed,
-            color: buttonColor,
-            splashColor: splashColor,
+            style: ButtonStyle(
+              backgroundColor: MaterialStateProperty.resolveWith<Color>((states) {
+                return buttonColor;
+              }),
+              overlayColor: MaterialStateProperty.resolveWith<Color>((states) {
+                if (states.contains(MaterialState.pressed)) {
+                  return splashColor;
+                }
+                return buttonColor;
+              }),
+            ),
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: contents,

--- a/lib/widgets/card-shopping.dart
+++ b/lib/widgets/card-shopping.dart
@@ -36,13 +36,15 @@ class CardShopping extends StatelessWidget {
                       decoration: BoxDecoration(
                         borderRadius: BorderRadius.all(Radius.circular(3.0)),
                       )),
-                  FlatButton(
-                    textColor: ArgonColors.white,
-                    color: ArgonColors.initial,
-                    onPressed: () {},
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(4.0),
+                  TextButton(
+                    style: TextButton.styleFrom(
+                      foregroundColor: ArgonColors.white,
+                      backgroundColor: ArgonColors.initial,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(4.0),
+                      ),
                     ),
+                    onPressed: () {},
                     child: Padding(
                       padding: EdgeInsets.only(
                           left: 5.0, right: 5.0, top: 12, bottom: 12),
@@ -97,15 +99,17 @@ class CardShopping extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        FlatButton(
-                          textColor: ArgonColors.white,
-                          color: ArgonColors.initial,
+                        TextButton(
+                          style: TextButton.styleFrom(
+                            foregroundColor: ArgonColors.white,
+                            backgroundColor: ArgonColors.initial,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(4.0),
+                            ),
+                          ),
                           onPressed: () {
                             deleteOnPress();
                           },
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(4.0),
-                          ),
                           child: Padding(
                               padding: EdgeInsets.only(
                                   left: 5.0, right: 5.0, top: 12, bottom: 12),
@@ -114,13 +118,15 @@ class CardShopping extends StatelessWidget {
                                       fontWeight: FontWeight.w600,
                                       fontSize: 11.0))),
                         ),
-                        FlatButton(
-                          textColor: ArgonColors.white,
-                          color: ArgonColors.initial,
-                          onPressed: () {},
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(4.0),
+                        TextButton(
+                          style: TextButton.styleFrom(
+                            foregroundColor: ArgonColors.white,
+                            backgroundColor: ArgonColors.initial,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(4.0),
+                            ),
                           ),
+                          onPressed: () {},
                           child: Padding(
                               padding: EdgeInsets.only(
                                   left: 5.0, right: 5.0, top: 12, bottom: 12),


### PR DESCRIPTION
# Summary

The Buttons were not working and needed a migration for the current version of Flutter (Nov 3, 2022)
```
Flutter 3.3.7 • channel stable • https://github.com/flutter/flutter.git
Framework • revision e99c9c7cd9 (2 days ago) • 2022-11-01 16:59:00 -0700
Engine • revision 857bd6b74c
Tools • Dart 2.18.4 • DevTools 2.15.0
```

I followed the docs from Flutter to migrate the buttons to get them in a working state:
https://docs.flutter.dev/release/breaking-changes/buttons#migrating-buttons-with-custom-colors